### PR TITLE
added timeout to prevent set up timing out

### DIFF
--- a/provision_card.sh
+++ b/provision_card.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env expect -f
+#!/usr/bin/expect -f
+set timeout 20
 
 send_user -- "Your name: "
 expect_user -re "(.*)\n"


### PR DESCRIPTION
Fixed bug which was causing script to fail.
Added timeout at beginning of file to give user more time to add email address.  